### PR TITLE
Fix configuring existing role bug

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -1,6 +1,6 @@
 locals {
   role_name                      = var.create && var.create_role ? coalesce(var.role_name, var.name, "*") : null
-  application_role_name          = var.create_application_role ? coalesce(var.application_role_name, "${var.name}-application-role", "*") : null
+  application_role_name          = coalesce(var.application_role_name, "${var.name}-application-role", "*")
   create_application_role_policy = var.create && var.create_application_role_policy
   add_backup_policies            = local.enable_s3_backup && var.s3_backup_use_existing_role
   add_kinesis_source_policy      = var.create && var.create_role && local.is_kinesis_source && var.kinesis_source_use_existing_role


### PR DESCRIPTION
Using the following setup didn't work (Same as one of the examples).

Configure existing Application Role to an application that runs in EC2 Instance with a policy with provided actions
```json

module "firehose" {
source = "fdmsantos/kinesis-firehose/aws"
version = "x.x.x"
name = "firehose-delivery-stream"
destination = "s3" # or destination = "extended_s3"
configure_existing_application_role = true
application_role_name = "application-role"
create_application_role_policy = true
application_role_policy_actions = [
"firehose:PutRecord",
"firehose:PutRecordBatch",
"firehose:CreateDeliveryStream",
"firehose:UpdateDestination"
]
}
```
I got an error name = "${local.application_role_name}-policy" is null.