### PR TITLE
fix: change kinesisDecrypt to kmsDecrypt

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -67,7 +67,7 @@ data "aws_iam_policy_document" "kinesis" {
     content {
       effect = "Allow"
       actions = [
-        "kinesis:Decrypt"
+        "kms:Decrypt"
       ]
       resources = [var.kinesis_source_kms_arn]
       condition {


### PR DESCRIPTION
When `kinesis_source_is_encrypted: true` and `kinesis_source_kms_arn` is specified to read the data from encrypted Kinesis stream, Firehose can't decrypt the data because has no permission to do this action
```
Firehose does not have access to the KMS Key used to encrypt/decrypt the Kinesis Stream. Please grant the Firehose delivery role access to the key.	

Kinesis.KMS.AccessDeniedException
```

Fix is simple, change `kinesis:Decrypt` to `kms:Decrypt` because there is no AWS action called `kinesis:Decrypt`