### PR TITLE
fix: variable data_format_conversion_input_format error_message #22

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -560,7 +560,7 @@ variable "data_format_conversion_input_format" {
   type        = string
   default     = "OpenX"
   validation {
-    error_message = "Valid values are HIVE and OPENX."
+    error_message = "Valid values are HIVE and OpenX."
     condition     = contains(["HIVE", "OpenX"], var.data_format_conversion_input_format)
   }
 }


### PR DESCRIPTION
Update `error_message` to display valid conditions.

https://github.com/fdmsantos/terraform-aws-kinesis-firehose/blob/main/variables.tf#L563

```terraform
variable "data_format_conversion_input_format" {
  description = "Specifies which deserializer to use. You can choose either the Apache Hive JSON SerDe or the OpenX JSON SerDe"
  type        = string
  default     = "OpenX"
  validation {
    error_message = "Valid values are HIVE and OPENX."
    condition     = contains(["HIVE", "OpenX"], var.data_format_conversion_input_format)
  }
}
```

Update to 
```
    error_message = "Valid values are HIVE and OpenX."
```
